### PR TITLE
Fix: IMPLIB_FLAG now only has a value on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,11 @@ else ifeq ($(CC),gcc)
 	SLIB_FLAG = -l$(1)
 	LIBPATH_FLAG = -L$(1)
 	DLL_FLAG = -shared
-	IMPLIB_FLAG = -Wl,--out-implib,$(1)
+	ifeq ($(OS),Windows_NT)
+		IMPLIB_FLAG = -Wl,--out-implib,$(1)
+	else
+		IMPLIB_FLAG =
+	endif
 	LINK_OPT =
 	NOEXP =
 	ifneq ($(OS),Windows_NT) # Linux


### PR DESCRIPTION
When IMPLIB_FLAG is non-empty on Linux, it probably raises an error while building because a shared library needs no implib on Linux.
The merge of this PR will close #10