### PR TITLE
Enhancement: Not to generate dependencies file when making some phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ else
 	./depends.sh $(SRC) $@
 endif
 
-ifneq ($(MAKECMDGOALS),$(BUILD)/depends.d)
+ifeq ($(filter clean clean-build help help-install install install-files-only uninstall uninstall-all $(BUILD)/depends.d,$(MAKECMDGOALS)),)
 -include $(BUILD)/depends.d
 endif
 


### PR DESCRIPTION
If when we run `make clean`, we also generate a dependencies file, it's a waste of time.
We should make the Makefile not to generate dependencies file when making some phony targets to save time and avoid 
misunderstanding: "Oh, why it generates a dependencies file when I `make clean`?"