### PR TITLE
Fix: Use RMDIR dir instead of RM dir/* to recursively remove the directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,11 +264,11 @@ directories:
 .PHONY: directories
 
 clean-build:
-	$(RM) $(call fix_path,$(BUILD)/*)
+	$(RMDIR) $(call fix_path,$(BUILD))
 .PHONY: clean-build
 
 clean: clean-build
-	$(RM) $(call fix_path,$(DIST)/*)
+	$(RMDIR) $(call fix_path,$(DIST))
 .PHONY: clean
 
 install-files-only: all


### PR DESCRIPTION
#21: 
> In the future, maybe we generate directories in build and dist directories.
But this causes a problem: $(RM) dir/* can only remove files in the
directory and it isn't recursive. We should use $(RMDIR) dir instead.