### PR TITLE
Replace `-std=c99` to `-std=gnu99` in CFLAGS which closes #26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ ifeq ($(CC),cl)
 		CFLAGS += /O2
 	endif
 else ifeq ($(CC),gcc)
-	CFLAGS += -std=c99 -Wall -fPIC -fvisibility=hidden
+	CFLAGS += -std=gnu99 -Wall -fPIC -fvisibility=hidden
 	ifeq ($(RELEASE),0)
 		CFLAGS += -O0 -DDEBUG -g
 	else


### PR DESCRIPTION
@user-name-beta
> In the future we may use some GNU extension or POSIX extension (such as readlink in branch admin/launch).
But -std=c99 disables these extensions, so we should replace it with -std=gnu99 to obtains these extensions.