### PR TITLE
Fix: Add __attribute__((unused)) before get_volume in path.c to avoid compiler warnings

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -10,6 +10,9 @@
 #include "path.h"
 #include "safe_string.h"
 
+#ifndef _WIN32
+__attribute__((unused)) // Unix systems have no volume concept.
+#endif
 static inline char
 get_volume(const char *path) {
 #ifndef _WIN32


### PR DESCRIPTION
Linux has no volume concept. Therefore, we should mark get_volume unused on Linux systems to avoid compiler warnings.