### PR TITLE
Fix: Always output with stderr in report_error.c to avoid order problems

### DIFF
--- a/src/report_error.c
+++ b/src/report_error.c
@@ -13,24 +13,24 @@
 void
 cp_report_fatal(const char *exename, const char *fmt, ...) {
     if(exename != NULL) {
-        printf("%s: ", exename);
+        fprintf(stderr, "%s: ", exename);
     }
     va_list args;
     va_start(args, fmt);
     vfprintf(stderr, fmt, args);
     va_end(args);
-    printf("\n");
+    fprintf(stderr, "\n");
     exit(1);
 }
 
 void
 cp_report_error(const char *exename, const char *fmt, ...) {
     if(exename != NULL) {
-        printf("%s: ", exename);
+        fprintf(stderr, "%s: ", exename);
     }
     va_list args;
     va_start(args, fmt);
     vfprintf(stderr, fmt, args);
     va_end(args);
-    printf("\n");
+    fprintf(stderr, "\n");
 }


### PR DESCRIPTION
Use both stdout and stderr may cause order problem because stdout has buffer but stderr has not. We should use stderr only.