### PR TITLE
Add -Werror and /WX to make the compiler see a warning as an error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,14 +75,14 @@ endif
 endif
 
 ifeq ($(CC),cl)
-	CFLAGS += /nologo /DYNAMICBASE
+	CFLAGS += /nologo /DYNAMICBASE /WX
 	ifeq ($(RELEASE),0)
 		CFLAGS += /Od /D_DEBUG
 	else
 		CFLAGS += /O2
 	endif
 else ifeq ($(CC),gcc)
-	CFLAGS += -std=gnu99 -Wall -fPIC -fvisibility=hidden
+	CFLAGS += -std=gnu99 -Wall -Werror -Wextra -fPIC -fvisibility=hidden
 	ifeq ($(RELEASE),0)
 		CFLAGS += -O0 -DDEBUG -g
 	else


### PR DESCRIPTION
The workflow is a little weak because it doesn't think that a warning is an error. This may make us ignore
some significant bugs in the program. To avoid this problem, we should make the compiler think *a warning
is an error*.