### PR TITLE
Change `cp` to `cpc` and announce the change of the program in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,17 @@ Since this project has only one contributor \([user-name-beta](https://github.co
 
 Use it as a command-line tool. Such as:
 
-`cp version`
+`cpc version`
 
 and it will print version information. As what we design, this command-line program has a group of sub commands like `version` (just like git).
 
 ### Naming conflict
-What you should pay attention to is that the name of cp is as same as a coreutil (which used to copy file) in Unix-like systems. This may make the execution of the real cp difficult. We are working on solving this issue.
+
+<!--What you should pay attention to is that the name of cp is as same as a coreutil (which used to copy file) in Unix-like systems. This may make the execution of the real cp difficult. We are working on solving this issue.-->
+<!--This issue is solved-->
+
+> [!NOTE] 
+> The name of the program was changed from `cp` to `cpc` to avoid naming conflict with the `cp` command in Unix-like systems on January 23, 2026.
 
 # Copyright
 


### PR DESCRIPTION
The previous pull request #47 forgets the README documentation. This pull request solves it.