### PR TITLE
Delete the installation of mingw toolchain in build.yml and install `base-devel` only.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,6 @@ jobs:
         msystem: mingw64
         update: true
         install: |
-          mingw-w64-x86_64-toolchain
           base-devel
       
     - name: make


### PR DESCRIPTION
The mingw takes a long time because it installs something we don't need such as python. This slows our development progress. We should solve it.