### PR TITLE
Delete release make check in .github/workflow/build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,6 @@ jobs:
     - name: test-run
       run: dist/cpc version
 
-    - name: make clean
-      run: make clean
-
-    - name: make release
-      run: make RELEASE=1
-
-    - name: release-test-run
-      run: dist/cpc version
-
   on-windows-with-msvc:
 
     runs-on: windows-latest
@@ -44,15 +35,6 @@ jobs:
       run: make
 
     - name: test-run
-      run: dist/cpc version
-
-    - name: make clean
-      run: make clean
-
-    - name: make release
-      run: make RELEASE=1
-
-    - name: release-test-run
       run: dist/cpc version
 
   on-windows-with-mingw:
@@ -74,13 +56,4 @@ jobs:
       run: make CC=gcc
 
     - name: test-run
-      run: dist/cpc version
-
-    - name: make clean
-      run: make clean CC=gcc
-
-    - name: make release
-      run: make RELEASE=1 CC=gcc
-      
-    - name: release-test-run
       run: dist/cpc version


### PR DESCRIPTION
The release check is not necessary. It has never checked even one error. 

This check takes us many time and we should delete it.