### PR TITLE
Add testrun-cleanup target and run this target first in test in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,10 @@ $(DIST)/cpc$(EXE_EXT): $(BUILD)/launch$(OBJ_EXT) $(CPIMPLIB) $(EXERES)
 
 # Define test targets
 
-TEST_TARGETS =
+testrun-cleanup:
+	@echo > $(call fix_path,$(BUILD)/Test/testrun$(BAT_EXT))
+
+TEST_TARGETS = testrun-cleanup
 
 WRITE_TEST_RUN = @echo $(call fix_path,$@) >> $(call fix_path,$(BUILD)/Test/testrun$(BAT_EXT))
 


### PR DESCRIPTION
If we don't clean up the build/Test/testrun[.bat, .sh] file first, the file might contain
repeating files, such as:

```
build/Test/platform/mmap.exe
build/Test/platform/mmap.exe # Oops! The same program!
```

So we should make it empty first.