### PR TITLE
Add declaration in parsearg.c and add `void` in the params

### DIFF
--- a/src/parsearg.c
+++ b/src/parsearg.c
@@ -22,7 +22,7 @@ pop(int index) {
 }
 
 int
-CP_ParseAssertNoMoreArgs() {
+CP_ParseAssertNoMoreArgs(void) {
     if(cp_argc > 0) {
         fprintf(stderr, "Warning: extra arguments: %s", cp_argv[0]);
         return -1;

--- a/src/parsearg.h
+++ b/src/parsearg.h
@@ -21,5 +21,6 @@ bool CP_ParseFlag(const char *flag);
 int CP_ParseFlagEx(int flagc, const char * const *flags);
 const char *CP_ParseOption(const char *option);
 int CP_ParseOptionEx(const char *option, int valuec, const char **values);
+int CP_ParseAssertNoMoreArgs(void);
 
 #endif /* _CP_PARSE_H_ */


### PR DESCRIPTION
CP_ParseAssertNoMoreArgs is defined in parsearg.c, but it has
no declaration in parsearg.h. This PR adds the declaration.