### PR TITLE
Add header guard and stddef include in safe_string.h

### DIFF
--- a/src/safe_string.h
+++ b/src/safe_string.h
@@ -6,7 +6,14 @@
 //
 // Safe string functions for C programming language.
 
+#ifndef _CP_SAFE_STRING_H_
+#define _CP_SAFE_STRING_H_
+
+#include <stddef.h>
+
 int strcat_safe(char *dst, const char *src, size_t dst_size);
 int strcpy_safe(char *dst, const char *src, size_t dst_size);
 int strncat_safe(char *dst, const char *src, size_t dst_size, size_t n);
 int strncpy_safe(char *dst, const char *src, size_t dst_size, size_t n);
+
+#endif /* _CP_SAFE_STRING_H_ */


### PR DESCRIPTION
safe_string.h misses header guard and `#include <stddef.h>`(needed by size_t).