### PR TITLE
Change the coding style

### DIFF
--- a/src/Test/platform/mmap.c
+++ b/src/Test/platform/mmap.c
@@ -19,7 +19,8 @@
 #endif
 
 int
-main() {
+main()
+{
     int ret;
     CPMemoryMapping map1;
     CPMemoryMapping map2;

--- a/src/commandline.c
+++ b/src/commandline.c
@@ -23,7 +23,8 @@
 #include <stdlib.h>
 
 int
-CPCommandLine_GetExecutablePath(char *dst) {
+CPCommandLine_GetExecutablePath(char *dst)
+{
 #ifdef _WIN32
     size_t len = GetModuleFileNameA(NULL, dst, CP_MAX_PATH);
     if(len == 0 || len >= CP_MAX_PATH) {
@@ -45,7 +46,8 @@ CPCommandLine_GetExecutablePath(char *dst) {
 }
 
 int
-CPCommandLine_PrintFile(const char *directory, const char *rel_path){
+CPCommandLine_PrintFile(const char *directory, const char *rel_path)
+{
     if(directory == NULL || rel_path == NULL) {
         return -1;
     }
@@ -65,7 +67,8 @@ CPCommandLine_PrintFile(const char *directory, const char *rel_path){
 }
 
 void
-CPCommandLine_PrintCopyright(void) {
+CPCommandLine_PrintCopyright(void)
+{
     printf("Copyright (c) 2025 user-name-beta. All rights reserved.\n");
     printf("Licensed under the MIT license.\n");
     printf("See LICENSE file in the software root for full license information.\n");
@@ -78,7 +81,8 @@ CPCommandLine_PrintCopyright(void) {
 }
 
 void
-CPCommandLine_PrintVersion(void) {
+CPCommandLine_PrintVersion(void)
+{
     printf("CP version %s\n", CP_VERSION_STRING);
     printf("Build date: %s %s\n", __DATE__, __TIME__);
 #ifdef _MSC_VER
@@ -93,7 +97,8 @@ CPCommandLine_PrintVersion(void) {
 }
 
 int
-CPCommandLine_GetHomeDirectory(char *dst, const char *exe) {
+CPCommandLine_GetHomeDirectory(char *dst, const char *exe)
+{
     char *home = getenv("CPLOCALHOME");
     if(home != NULL) {
         if(strcpy_safe(dst, home, CP_MAX_PATH) != 0)return -1;
@@ -105,11 +110,13 @@ CPCommandLine_GetHomeDirectory(char *dst, const char *exe) {
 }
 
 int
-CPCommandLine_PrintLicense(const char *home) {
+CPCommandLine_PrintLicense(const char *home)
+{
     return CPCommandLine_PrintFile(home, "LICENSE");
 }
 
 int
-CPCommandLine_PrintHelp(const char *home, const char *helpfile) {
+CPCommandLine_PrintHelp(const char *home, const char *helpfile)
+{
     return CPCommandLine_PrintFile(home, helpfile);
 }

--- a/src/cpc/launch.c
+++ b/src/cpc/launch.c
@@ -8,6 +8,8 @@
 
 #include "main.h"
 
-int main(int argc, char **argv) {
+int 
+main(int argc, char **argv)
+{
     return CPMainProgramEntryPoint_CPC(argc, argv);
 }

--- a/src/cpc/main.c
+++ b/src/cpc/main.c
@@ -24,7 +24,8 @@ static char buf1[CP_MAX_PATH];
 static char buf2[CP_MAX_PATH];
 static char exe_name[CP_MAX_PATH];
 
-static int init_program_path(void) {
+static int init_program_path(void)
+{
     if(CPCommandLine_GetExecutablePath(buf1) == 0) {
         exe = buf1;
     } else {
@@ -45,7 +46,8 @@ static int init_program_path(void) {
 }
 
 CP_API_FUNC(int)
-CPMainProgramEntryPoint_CPC(int argc, char **argv) {
+CPMainProgramEntryPoint_CPC(int argc, char **argv)
+{
     if(main_running) {
         cp_report_fatal("cpc", "Recursive call to main entry point.");
         return -1;

--- a/src/parsearg.c
+++ b/src/parsearg.c
@@ -14,7 +14,8 @@ int cp_argc;
 char **cp_argv;
 
 static inline void
-pop(int index) {
+pop(int index)
+{
     for(int i = index; i < cp_argc - 1; i++) {
         cp_argv[i] = cp_argv[i+1];
     }
@@ -22,7 +23,8 @@ pop(int index) {
 }
 
 int
-CP_ParseAssertNoMoreArgs(void) {
+CP_ParseAssertNoMoreArgs(void)
+{
     if(cp_argc > 0) {
         fprintf(stderr, "Error: extra arguments: %s\n", cp_argv[0]);
         return -1;
@@ -31,7 +33,8 @@ CP_ParseAssertNoMoreArgs(void) {
 }
 
 const char *
-CP_ParseOneArg(void) {
+CP_ParseOneArg(void)
+{
     /* Parse next argument */
     if(cp_argc == 0) {
         return NULL;
@@ -42,7 +45,8 @@ CP_ParseOneArg(void) {
 }
 
 int
-CP_ParseFlag(const char *flag) {
+CP_ParseFlag(const char *flag)
+{
     /* Parse --flag or -f */
     for(int i = 0; i < cp_argc; i++) {
         if(strcmp(cp_argv[i], flag) == 0){
@@ -54,7 +58,8 @@ CP_ParseFlag(const char *flag) {
 }
 
 int
-CP_ParseFlagEx(int flagc, const char * const *flags) {
+CP_ParseFlagEx(int flagc, const char * const *flags)
+{
     /* Parse exclusive multiple flags */
     int rv = -1;
     for(int i = 0; i < cp_argc; i++) {
@@ -75,7 +80,8 @@ CP_ParseFlagEx(int flagc, const char * const *flags) {
 }
 
 const char *
-CP_ParseOption(const char *option) {
+CP_ParseOption(const char *option)
+{
     /* Parse -option value */
 
     size_t len = strlen(option);
@@ -111,7 +117,8 @@ CP_ParseOption(const char *option) {
 }
 
 int
-CP_ParseOptionEx(const char *option, int valuec, const char **values) {
+CP_ParseOptionEx(const char *option, int valuec, const char **values)
+{
     int count = 0;
     size_t len = strlen(option);
     for(int i = 0; i < cp_argc; i++) {

--- a/src/path.c
+++ b/src/path.c
@@ -14,7 +14,8 @@
 __attribute__((unused)) // Unix systems have no volume concept.
 #endif
 static inline char
-get_volume(const char *path) {
+get_volume(const char *path)
+{
 #ifndef _WIN32
     (void)path; // unused
     return '\0';
@@ -27,7 +28,8 @@ get_volume(const char *path) {
 }
 
 static inline void
-remove_end_sep(char *path) {
+remove_end_sep(char *path)
+{
     size_t len = strlen(path);
     if(len > 0 && CP_IS_PATH_SEP(path[len-1])) {
         path[len-1] = '\0';
@@ -35,7 +37,8 @@ remove_end_sep(char *path) {
 }
 
 bool
-CPath_IsAbsolute(const char *path) {
+CPath_IsAbsolute(const char *path)
+{
 #ifdef _WIN32
     return get_volume(path) != '\0';
 #else
@@ -47,7 +50,8 @@ CPath_IsAbsolute(const char *path) {
 }
 
 int
-CPath_Getcwd(char *cwd) {
+CPath_Getcwd(char *cwd)
+{
     if(cwd == NULL)return -1;
 #ifdef _WIN32
     DWORD len = GetCurrentDirectoryA(CP_MAX_PATH, cwd);
@@ -64,7 +68,8 @@ CPath_Getcwd(char *cwd) {
 }
 
 int
-CPath_Setcwd(const char *path) {
+CPath_Setcwd(const char *path)
+{
     if(path == NULL)return -1;
 #ifdef _WIN32
     if(SetCurrentDirectoryA(path) == 0) {
@@ -79,7 +84,8 @@ CPath_Setcwd(const char *path) {
 }
 
 int
-CPath_Join(char *dst, const char *src1, const char *src2) {
+CPath_Join(char *dst, const char *src1, const char *src2)
+{
     if(dst == NULL || src1 == NULL || src2 == NULL)return -1;
     if(CPath_IsAbsolute(src2)) {
         return -1;
@@ -93,7 +99,8 @@ CPath_Join(char *dst, const char *src1, const char *src2) {
 }
 
 int
-CPath_JoinInPlace(char *dst, const char *src) {
+CPath_JoinInPlace(char *dst, const char *src)
+{
     if(dst == NULL || src == NULL)return -1;
     if(CPath_IsAbsolute(src)) {
         return -1;
@@ -106,7 +113,8 @@ CPath_JoinInPlace(char *dst, const char *src) {
 }
 
 int
-CPath_Filename(char *dst, const char *src) {
+CPath_Filename(char *dst, const char *src)
+{
     if(dst == NULL || src == NULL)return -1;
     size_t len = strlen(src);
     for(ssize_t i = (ssize_t)len - 1; i >= 0; i--) {
@@ -120,7 +128,8 @@ CPath_Filename(char *dst, const char *src) {
 }
 
 int
-CPath_Dirname(char *dst, const char *src) {
+CPath_Dirname(char *dst, const char *src)
+{
     if(dst == NULL || src == NULL)return -1;
     size_t len = strlen(src);
     for(ssize_t i = len - 1; i >= 0; i--) {

--- a/src/platform/mmap.c
+++ b/src/platform/mmap.c
@@ -39,7 +39,8 @@ typedef int flags_t;
 #endif
 
 static inline file_t
-convert_file_to_handle_or_fd(FILE *file) {
+convert_file_to_handle_or_fd(FILE *file)
+{
 #ifdef _WIN32
     if(file == NULL)return INVALID_HANDLE_VALUE;
     return (HANDLE) _get_osfhandle(_fileno(file));
@@ -50,7 +51,8 @@ convert_file_to_handle_or_fd(FILE *file) {
 }
 
 static inline size_t
-convert_size(file_t file, size_t size) {
+convert_size(file_t file, size_t size)
+{
     if(size != (size_t)-1)  {
         return size;
     }
@@ -70,7 +72,8 @@ convert_size(file_t file, size_t size) {
 }
 
 static inline prot_t
-convert_prot(int prot, int flags) {
+convert_prot(int prot, int flags)
+{
 #ifdef _WIN32
     int r = prot & CP_MMAP_PROT_READ;
     int w = prot & CP_MMAP_PROT_WRITE;
@@ -103,7 +106,8 @@ convert_prot(int prot, int flags) {
 }
 
 static inline flags_t
-convert_flags(file_t file, prot_t p, int flags) {
+convert_flags(file_t file, prot_t p, int flags)
+{
 #ifdef _WIN32
     (void)file; // unused
     (void)flags; // unused
@@ -144,7 +148,8 @@ convert_flags(file_t file, prot_t p, int flags) {
 }
 
 int 
-CPMemoryMapping_Create(CPMemoryMapping *mapping, FILE *file, size_t size, size_t offset, int prot, int flags) {
+CPMemoryMapping_Create(CPMemoryMapping *mapping, FILE *file, size_t size, size_t offset, int prot, int flags)
+{
     file_t handle = convert_file_to_handle_or_fd(file);
     size = convert_size(handle, size);
     if(size == (size_t)-1) {
@@ -184,7 +189,8 @@ CPMemoryMapping_Create(CPMemoryMapping *mapping, FILE *file, size_t size, size_t
 #endif
 }
 
-int CPMemoryMapping_Protect(CPMemoryMapping *mapping, size_t offset, size_t size, int prot) {
+int CPMemoryMapping_Protect(CPMemoryMapping *mapping, size_t offset, size_t size, int prot)
+{
     if(size == (size_t)-1) {
         size = mapping->size;
     }
@@ -201,7 +207,8 @@ int CPMemoryMapping_Protect(CPMemoryMapping *mapping, size_t offset, size_t size
     return 0;
 }
 
-int CPMemoryMapping_Destroy(CPMemoryMapping *mapping) {
+int CPMemoryMapping_Destroy(CPMemoryMapping *mapping)
+{
 #ifdef _WIN32
     UnmapViewOfFile(mapping->addr);
     CloseHandle(mapping->hMapping);

--- a/src/platform/mmap.h
+++ b/src/platform/mmap.h
@@ -19,8 +19,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-typedef 
-struct _CPMemoryMapping_ {
+typedef struct {
     void *addr;
     size_t size;
 #ifdef _WIN32

--- a/src/report_error.c
+++ b/src/report_error.c
@@ -11,7 +11,8 @@
 #include <stdlib.h>
 
 void
-cp_report_fatal(const char *exename, const char *fmt, ...) {
+cp_report_fatal(const char *exename, const char *fmt, ...)
+{
     if(exename != NULL) {
         fprintf(stderr, "%s: ", exename);
     }
@@ -24,7 +25,8 @@ cp_report_fatal(const char *exename, const char *fmt, ...) {
 }
 
 void
-cp_report_error(const char *exename, const char *fmt, ...) {
+cp_report_error(const char *exename, const char *fmt, ...)
+{
     if(exename != NULL) {
         fprintf(stderr, "%s: ", exename);
     }

--- a/src/safe_string.c
+++ b/src/safe_string.c
@@ -11,7 +11,8 @@
 #include <stddef.h> // for size_t
 
 int
-strcat_safe(char *dst, const char *src, size_t dst_size) {
+strcat_safe(char *dst, const char *src, size_t dst_size)
+{
     size_t dst_len = strlen(dst);
     size_t src_len = strlen(src);
     if(dst_len + src_len + 1 > dst_size) {
@@ -25,7 +26,8 @@ strcat_safe(char *dst, const char *src, size_t dst_size) {
 }
 
 int
-strcpy_safe(char *dst, const char *src, size_t dst_size) {
+strcpy_safe(char *dst, const char *src, size_t dst_size)
+{
     size_t src_len = strlen(src);
     if(src_len + 1 > dst_size) {
         return -1;
@@ -38,7 +40,8 @@ strcpy_safe(char *dst, const char *src, size_t dst_size) {
 }
 
 int
-strncat_safe(char *dst, const char *src, size_t dst_size, size_t n) {
+strncat_safe(char *dst, const char *src, size_t dst_size, size_t n)
+{
     size_t dst_len = strlen(dst);
     size_t src_len = strlen(src);
     if(n > src_len) {
@@ -55,7 +58,8 @@ strncat_safe(char *dst, const char *src, size_t dst_size, size_t n) {
 }
 
 int
-strncpy_safe(char *dst, const char *src, size_t dst_size, size_t n) {
+strncpy_safe(char *dst, const char *src, size_t dst_size, size_t n)
+{
     size_t src_len = strlen(src);
     if(n > src_len) {
         n = src_len;


### PR DESCRIPTION
In the past, we define a function like this:
```c
int
function(type arg1, type arg2, ...) {
...
}
```
But now we define a function like that:
```c
int
function(type arg1, type arg2, ...)
{
...
}
```
Also, we define a type now like this:
```
typedef int type;
typedef [struct, union] {
...
}
```
This should be a standard.