### PR TITLE
Change coding style

### DIFF
--- a/src/platform/mmap.h
+++ b/src/platform/mmap.h
@@ -19,7 +19,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
-typedef struct {
+typedef struct
+{
     void *addr;
     size_t size;
 #ifdef _WIN32


### PR DESCRIPTION
We now use this:
```c
typedef [struct, union]
{
    ...
}
```
instead of:
```c
typedef [struct,union] {
    ...
}
```