### PR TITLE
Copy quietly on Windows via xcopy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq ($(OS),Windows_NT)
 	SHELL := cmd.exe
 	RM = del /Q
 	RMDIR = rmdir /Q /S
-	COPY = copy /Q /Y
+	COPY = xcopy /Q /Y
 	EXE_EXT = .exe
 	LIB_PREFIX =
 	SO_EXT = .dll

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq ($(OS),Windows_NT)
 	SHELL := cmd.exe
 	RM = del /Q
 	RMDIR = rmdir /Q /S
-	COPY = copy
+	COPY = copy /Q /Y
 	EXE_EXT = .exe
 	LIB_PREFIX =
 	SO_EXT = .dll


### PR DESCRIPTION
Normal `copy` command always prints:

`1 file(s) copied.`

This is unnecessary and not pretty, especially compiling concurrently:

```
1 file(s) copied.
1 file(s) copied.
```

This PR avoids this by using `xcopy` which supports to specify `/Q` to enable quiet mode.

* `make` also passes `/Y` to `xcopy`.