### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: make
       run: make
@@ -39,7 +39,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: set up MSVC 2022
       uses: ilammy/msvc-dev-cmd@v1
       with:
@@ -62,7 +62,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: set up mingw
       uses: msys2/setup-msys2@v2

--- a/.github/workflows/change-year.yml
+++ b/.github/workflows/change-year.yml
@@ -23,7 +23,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Import GPG key and configure git 
       uses: crazy-max/ghaction-import-gpg@v5 

--- a/.github/workflows/headers_syntax.yml
+++ b/.github/workflows/headers_syntax.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Check Header Syntax
       run: |


### PR DESCRIPTION
Turn:
`actions/checkout@v4`
to:
`actions/checkout@v5`

since v4 uses `Node 20`, but it is deprecated in GitHub Actions:

> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
