### PR TITLE
Add workflow_dispatch to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,13 @@ on:
       - 'src/**'
       - 'Makefile'
       - '.github/workflows/build.yml'
+  
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The git ref to build (branch, tag, or commit SHA).'
+        required: false
+        default: 'main'
 
 jobs:
   on-linux:
@@ -21,6 +28,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{ github.event.inputs.ref || github.ref }}
 
     - name: make
       run: make


### PR DESCRIPTION
Add workflow_dispatch to .github/workflows/build.yml, allowing users
 to specify a ref argument for the git repository to checkout