### PR TITLE
Remove support for msvc toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,29 +43,6 @@ jobs:
     - name: testrun
       run: build/Test/testrun.sh
 
-  on-windows-with-msvc:
-
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v5
-    - name: set up MSVC 2022
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        vsversion: 2022
-
-    - name: make
-      run: make
-
-    - name: test-run
-      run: dist/cpc --version
-    
-    - name: make test
-      run: make test
-    
-    - name: testrun
-      run: cmd /c build\Test\testrun.bat
-
   on-windows-with-mingw:
 
     runs-on: windows-latest

--- a/src/commandline.c
+++ b/src/commandline.c
@@ -91,9 +91,7 @@ CPCommandLine_PrintVersion(void)
 {
     printf("CP version %s\n", CP_VERSION_STRING);
     printf("Build date: %s %s\n", __DATE__, __TIME__);
-#ifdef _MSC_VER
-    printf("Compiler: Microsoft Visual Studio %d.%d\n", _MSC_VER / 100, _MSC_VER % 100);
-#elif defined(__GNUC__)
+#if defined(__GNUC__)
     printf("Compiler: GCC %d.%d.%d\n", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
 #else
     printf("Compiler: unknown\n");

--- a/src/cptypes.h
+++ b/src/cptypes.h
@@ -36,8 +36,6 @@ typedef SSIZE_T ssize_t;
 
 #ifdef __GNUC__
 #define CP_ALWYAS_INLINE __attribute__((always_inline)) inline
-#elif defined(_MSC_VER)
-#define CP_ALWYAS_INLINE __forceinline inline
 #else
 #define CP_ALWYAS_INLINE inline
 #endif
@@ -46,8 +44,6 @@ typedef SSIZE_T ssize_t;
 
 #ifdef __GNUC__
 #define CP_UNREACHABLE() __builtin_unreachable()
-#elif defined(_MSC_VER)
-#define CP_UNREACHABLE() __assume(0)
 #else
 #define CP_UNREACHABLE() do {
     assert(0 && "Unreachable code reached");


### PR DESCRIPTION
MSVC toolchain is unnecessary. We shall REMOVE it.

1. MSYS2 and GCC toolchain can solve almost anything MSVC can, but reverse is not always true.
2. I work on a Linux computer currently, meaning that debugging problems caused by MSVC (which is used on Windows) is difficult. And we do not know MSVC well, too.