### PR TITLE
Remove src/cpc_src/help.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ TEST_TARGETS += $(BUILD)/Test/platform/mmap$(EXE_EXT)
 
 # Define target all as a default target
 
-TARGET = directories $(CPIMPLIB) $(DIST)/cpc$(EXE_EXT) api_headers $(DIST)/LICENSE $(DIST)/cpc-help.txt
+TARGET = directories $(CPIMPLIB) $(DIST)/cpc$(EXE_EXT) api_headers $(DIST)/LICENSE
 all: $(TARGET)
 .PHONY: all
 .DEFAULT_GOAL := all

--- a/Makefile
+++ b/Makefile
@@ -196,9 +196,6 @@ LOCALPREFIX = $(PREFIX)/$(VERSION)
 $(DIST)/LICENSE: LICENSE
 	$(COPY) $< $@
 
-$(DIST)/cpc-help.txt: $(SRC)/cpc_src/help.txt
-	$(COPY) $(call fix_path,$<) $(call fix_path,$@)
-
 # Define API headers
 
 API_HEADERS = # No API headers yet.

--- a/src/cpc_src/help.txt
+++ b/src/cpc_src/help.txt
@@ -1,9 +1,0 @@
-Usage: cpc --version
-   or: cpc --copyright
-   or: cpc --license
-   or: cpc --help
-
-    --version       Show version information
-    --copyright     Show copyright information
-    --license       Show license information
-    --help          Show this help information

--- a/src/cpc_src/main.c
+++ b/src/cpc_src/main.c
@@ -79,7 +79,17 @@ CPMainProgramEntryPoint_CPC(int argc, char **argv)
         CPCommandLine_PrintLicense(home);goto end;
     }
     if(CP_ParseFlag("--help") == 1) {
-        CPCommandLine_PrintHelp(home, "cpc-help.txt");goto end;
+        printf("Usage: cpc --version\n");
+        printf("           or: cpc --copyright\n");
+        printf("           or: cpc --license\n");
+        printf("           or: cpc --help\n");
+        printf("\n");
+        printf("            --version       Show version information\n");
+        printf("            --copyright     Show copyright information\n");
+        printf("            --license       Show license information\n");
+        printf("            --help          Show this help information\n");
+        printf("\n");
+
     }
     CPCommandLine_PrintHelp(home, "cpc-help.txt");
     goto error;

--- a/src/cpc_src/main.c
+++ b/src/cpc_src/main.c
@@ -21,6 +21,7 @@
 #include <path.h>
 #include <report_error.h>
 #include <commandline.h>
+#include <stdio.h>
 
 #include "main.h"
 


### PR DESCRIPTION
Remove src/cpc_src/help.txt and put the help message in main.c.

Put a single `cpc-help.txt` is bad because the program doesn't know where it is (is /usr/bin/cpc? or /var/git/cp/src/.libs/cpc?). Therefore, the program cannot find it in the probability of *99%*, even if it is just compiled locally.

*(Also, the `--license` commandline option is unnecessary and it may be removed too.)*