### PR TITLE
Remove the `--license` option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,16 +191,6 @@ ifeq ($(origin PREFIX),undefined)
 endif
 LOCALPREFIX = $(PREFIX)/$(VERSION)
 
-# Define other targets
-
-<<<<<<< HEAD
-$(DIST)/cpc-help.txt: $(SRC)/cpc_src/help.txt
-	$(COPY) $(call fix_path,$<) $(call fix_path,$@)
-=======
-$(DIST)/LICENSE: LICENSE
-	$(COPY) $< $@
->>>>>>> main
-
 # Define API headers
 
 API_HEADERS = # No API headers yet.

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ TEST_TARGETS += $(BUILD)/Test/platform/mmap$(EXE_EXT)
 
 # Define target all as a default target
 
-TARGET = directories $(CPIMPLIB) $(DIST)/cpc$(EXE_EXT) api_headers $(DIST)/LICENSE $(DIST)/cpc-help.txt
+TARGET = directories $(CPIMPLIB) $(DIST)/cpc$(EXE_EXT) api_headers $(DIST)/cpc-help.txt
 all: $(TARGET)
 .PHONY: all
 .DEFAULT_GOAL := all

--- a/Makefile
+++ b/Makefile
@@ -193,9 +193,6 @@ LOCALPREFIX = $(PREFIX)/$(VERSION)
 
 # Define other targets
 
-$(DIST)/LICENSE: LICENSE
-	$(COPY) $< $@
-
 $(DIST)/cpc-help.txt: $(SRC)/cpc_src/help.txt
 	$(COPY) $(call fix_path,$<) $(call fix_path,$@)
 

--- a/src/cpc_src/help.txt
+++ b/src/cpc_src/help.txt
@@ -5,5 +5,4 @@ Usage: cpc --version
 
     --version       Show version information
     --copyright     Show copyright information
-    --license       Show license information
     --help          Show this help information

--- a/src/cpc_src/main.c
+++ b/src/cpc_src/main.c
@@ -75,9 +75,6 @@ CPMainProgramEntryPoint_CPC(int argc, char **argv)
     if(CP_ParseFlag("--version") == 1) {
         CPCommandLine_PrintVersion();goto end;
     }
-    if(CP_ParseFlag("--license") == 1) {
-        CPCommandLine_PrintLicense(home);goto end;
-    }
     if(CP_ParseFlag("--help") == 1) {
         CPCommandLine_PrintHelp(home, "cpc-help.txt");goto end;
     }


### PR DESCRIPTION
Remove the `--license` option in main.c
Remove the `license` target in Makefile
Remove the `--license` option introduction in help.txt

A `--license` option is unnecessary and the program can even hardly find the `LICENSE` file. Therefore, this pull request purposes to remove it.