### PR TITLE
Remove the use of `__DATE__` and` __TIME__`

### DIFF
--- a/src/commandline.c
+++ b/src/commandline.c
@@ -70,7 +70,6 @@ void
 CPCommandLine_PrintVersion(void)
 {
     printf("CP version %s\n", CP_VERSION_STRING);
-    printf("Build date: %s %s\n", __DATE__, __TIME__);
 #if defined(__GNUC__)
     printf("Compiler: GCC %d.%d.%d\n", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
 #else


### PR DESCRIPTION
Print the build date and time is not necessary and this prevents reproducible builds.

Modify src/commandline.c